### PR TITLE
global unreachable code elimination complete

### DIFF
--- a/src/edu/mit/compilers/cfg/CFG.java
+++ b/src/edu/mit/compilers/cfg/CFG.java
@@ -11,6 +11,11 @@ import java.util.*;
 public class CFG {
 
     private final LlBuilder builder;
+
+    public ArrayList<BasicBlock> getBasicBlocks() {
+        return basicBlocks;
+    }
+
     private final ArrayList<BasicBlock> basicBlocks;
     private final LinkedHashMap<BasicBlock, String> blockLabels;
 

--- a/src/edu/mit/compilers/cfg/GlobalURE.java
+++ b/src/edu/mit/compilers/cfg/GlobalURE.java
@@ -1,0 +1,45 @@
+package edu.mit.compilers.cfg;
+
+import edu.mit.compilers.ll.LlEmptyStmt;
+import edu.mit.compilers.ll.LlStatement;
+
+import java.util.HashSet;
+import java.util.Map;
+
+/**
+ * Created by madhav on 12/8/16.
+ */
+public class GlobalURE {
+
+    //Recursive function to DFS on the
+    private static void recursiveGlobalURE(BasicBlock node, HashSet<BasicBlock> visited) {
+
+        //Check if node is already visited
+        if (visited.contains(node))
+            return;
+
+        visited.add(node);
+        BasicBlock defaultBranch = node.getDefaultBranch();
+        BasicBlock alternateBranch = node.getAlternativeBranch();
+
+        if (defaultBranch != null)
+            recursiveGlobalURE(defaultBranch, visited);
+
+        if (alternateBranch != null)
+            recursiveGlobalURE(alternateBranch, visited);
+    }
+
+    public static void performGlobalURE(CFG cfg) {
+        HashSet<BasicBlock> visited = new HashSet<>();
+        recursiveGlobalURE(cfg.getRootBasicBlock(), visited);
+
+        for (BasicBlock basicBlock : cfg.getBasicBlocks()) {
+            //If block cannot be reached from root node, eliminate as unreachable code
+            if (!visited.contains(basicBlock)) {
+                for (Map.Entry<String, LlStatement> statementMap : basicBlock.getLabelsToStmtsMap().entrySet()) {
+                    basicBlock.getLabelsToStmtsMap().put(statementMap.getKey(), new LlEmptyStmt());
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Changes all unreachable code statements with empty statements. Labels and order of labels is maintained. 